### PR TITLE
Made normalized_score a double[3]

### DIFF
--- a/cld.cc
+++ b/cld.cc
@@ -147,7 +147,7 @@ PHPAPI int cld_detect_language(zval **result, char *text, int text_len, int is_p
 
 	char *language_name;
 
-	double normalized_score;
+	double normalized_scores[3];
 
 	zval *detail;
 
@@ -179,7 +179,7 @@ PHPAPI int cld_detect_language(zval **result, char *text, int text_len, int is_p
 
 	CompactLangDet::DetectLanguage(0, text, text_len, is_plain_text,
 		include_extended_languages, 1, 0, top_level_domain_hint, encoding_hint,
-		language_hint, languages, percentages, &normalized_score, &bytes, &reliable);
+		language_hint, languages, percentages, normalized_scores, &bytes, &reliable);
 
 
 	array_init(*result);

--- a/cld.cc
+++ b/cld.cc
@@ -200,6 +200,8 @@ PHPAPI int cld_detect_language(zval **result, char *text, int text_len, int is_p
 		add_assoc_string(detail, "code", (char *)ExtLanguageCode(language), 1);
 		add_assoc_bool(detail, "reliable", reliable);
 		add_assoc_long(detail, "bytes", bytes);
+		add_assoc_double(detail, "score", normalized_scores[i]);
+		add_assoc_long(detail, "percent", percentages[i]);
 		add_next_index_zval(*result, detail);
 	}
 

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
 	</stability>
 	<license uri="http://www.opensource.org/licenses/bsd-license.php">BSD License</license>
 	<notes>
-- ???
+- CLD\detect() and CLD\Detector::detectLanguage() now return scores and percentages (Arnaud Le Blanc)
 	</notes>
 	<contents>
 		<dir name="/">


### PR DESCRIPTION
This changes normalized_score variable to a double[3] since CompactLangDet::DetectLanguage apparently takes a double[3]. (I was seeing many INVALID_LANGUAGE returned from detect(), it turns out that CLD was overriding languages[0] when writing to (&normalized_score)[1].)

I've also included a change that return scores and percentages from from detect().
